### PR TITLE
Allow CORS and a default 200 response at the root

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,11 +29,16 @@ class DatGateway {
       maxAge
     })
     this.server = http.createServer((req, res) => {
+      res.setHeader("Access-Control-Allow-Origin", "*")
       log('%s %s', req.method, req.url)
       // TODO redirect /:key to /:key/
       let urlParts = req.url.split('/')
       let address = urlParts[1]
       let path = urlParts.slice(2).join('/')
+      if (!address) {
+        res.writeHead(200)
+        return res.end('dat-gateway')
+      }
       return this.resolveDat(address).then((key) => {
         return this.getDat(key)
       }).then((dat) => {


### PR DESCRIPTION
This enables CORs and will respond with a 200 at the root of the server. Why does this matter? 

Here's a PoC I whipped up that relies primarily on a local dat-gateway when available, but falls back to a public gateway when not available locally.

The PoC Bunsen app served up through a public gateway:
<img width="888" alt="screen shot 2018-04-12 at 12 34 15 pm" src="https://user-images.githubusercontent.com/156575/38691597-4722d4f4-3e4f-11e8-9bf9-1b1c20159e13.png">

The PoC Bunsen app serving up the requested dat through the local gateway because it is available:
<img width="1197" alt="screen shot 2018-04-12 at 12 32 30 pm" src="https://user-images.githubusercontent.com/156575/38691665-7dbf62fc-3e4f-11e8-911e-8ebf3de30375.png">

The PoC Bunsen app serving up the requested dat through the public gateway because the local gateway is not available:
<img width="1184" alt="screen shot 2018-04-12 at 12 32 52 pm" src="https://user-images.githubusercontent.com/156575/38691669-820bebdc-3e4f-11e8-93ed-de0370915781.png">

The CORs and the response at the root is important because before setting the iframe to the gateway, we do a preflight fetch to see if there is a 127.0.01:3000 gateway available.

